### PR TITLE
Add GoLang Workspace

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,0 +1,8 @@
+go 1.19
+
+use (
+	./basic
+	./hackerrank
+	./linkedLists
+	./sortAlgorithms
+)


### PR DESCRIPTION
We can use the [workspace](https://go.dev/doc/tutorial/workspaces) with the new 1.18 Go Programming language version.

It will help manage the multi-modules directory. Anyone [can get familiar with workspaces](https://go.dev/blog/get-familiar-with-workspaces).